### PR TITLE
Fix @:increment using previous value for marking

### DIFF
--- a/hxbit/Macros.hx
+++ b/hxbit/Macros.hx
@@ -1601,7 +1601,7 @@ class Macros {
 		var needRef = false;
 		if( t.increment != null ) {
 			needRef = true;
-			mark = macro if( Math.floor(this.$fname / $v{t.increment}) != this.$rname ) { this.$rname = Math.floor(this.$fname / $v{t.increment}); $mark; };
+			mark = macro if( Math.floor(v / $v{t.increment}) != this.$rname ) { this.$rname = Math.floor(v / $v{t.increment}); $mark; };
 		}
 		if( t.condSend != null ) {
 			function loop(e:Expr) {
@@ -1616,7 +1616,7 @@ class Macros {
 				return macro {}; // no marking
 			var condSend = loop(t.condSend);
 			needRef = true;
-			mark = macro if( $condSend ) { this.$rname = this.$fname; $mark; };
+			mark = macro if( $condSend ) { this.$rname = v; $mark; };
 		}
 		if( needRef && fields != null )
 			fields.push({


### PR DESCRIPTION
Fix missing markings, because in the set_ function the marking is done before the affectation. 

Code after change:

	function set_reviveRemaining(v:Float) {
		if ((this.reviveRemaining != v)) {
			if ((Math.floor(v / 0.05) != this.__ref_reviveRemaining)) {
				this.__ref_reviveRemaining = Math.floor(v / 0.05);
				if ((this.__host != null && (this.__host.isAuth || this.__host.checkWrite(this, 20)) && (this.__next != null || this.__host.mark(this)))) this.__bits |= 1048576;
			};
		};
		return this.reviveRemaining = v;
	}

Code before change:

	function set_reviveRemaining(v:Float) {
		if ((this.reviveRemaining != v)) {
			if ((Math.floor(this.reviveRemaining / 0.05) != this.__ref_reviveRemaining)) {
				this.__ref_reviveRemaining = Math.floor(this.reviveRemaining / 0.05);
				if ((this.__host != null && (this.__host.isAuth || this.__host.checkWrite(this, 20)) && (this.__next != null || this.__host.mark(this)))) this.__bits |= 1048576;
			};
		};
		return this.reviveRemaining = v;
	}