### PR TITLE
Null safety project support

### DIFF
--- a/hxbit/Serializer.hx
+++ b/hxbit/Serializer.hx
@@ -230,7 +230,11 @@ class Serializer {
 	public inline function getArray<T>(f:Void->T) : Array<T> {
 		var len = getInt();
 		if( len == 0 )
+			#if hxbit_nullsafety
+			return [];
+			#else
 			return null;
+			#end
 		len--;
 		var a = [];
 		for( i in 0...len )
@@ -241,7 +245,11 @@ class Serializer {
 	public inline function getVector<T>(f:Void->T) : haxe.ds.Vector<T> {
 		var len = getInt();
 		if( len == 0 )
+			#if hxbit_nullsafety
+			return new haxe.ds.Vector<T>(0);
+			#else
 			return null;
+			#end
 		len--;
 		var a = new haxe.ds.Vector<T>(len);
 		for( i in 0...len )
@@ -265,7 +273,11 @@ class Serializer {
 	@:extern public inline function getMap<K,T>(fk:Void->K, ft:Void->T) : Map<K,T> {
 		var len = getInt();
 		if( len == 0 )
+			#if hxbit_nullsafety
+			return new Map<K,T>();
+			#else
 			return null;
+			#end
 		var m = new Map<K,T>();
 		while( --len > 0 ) {
 			var k = fk();
@@ -347,7 +359,11 @@ class Serializer {
 	public inline function getString() {
 		var len = getInt();
 		if( len == 0 )
+			#if hxbit_nullsafety
+			return "";
+			#else
 			return null;
+			#end
 		len--;
 		var s = input.getString(inPos, len);
 		inPos += len;
@@ -357,7 +373,11 @@ class Serializer {
 	public inline function getBytes() {
 		var len = getInt();
 		if( len == 0 )
+			#if hxbit_nullsafety
+			return haxe.io.Bytes.alloc(0);
+			#else
 			return null;
+			#end
 		len--;
 		var s = input.sub(inPos, len);
 		inPos += len;


### PR DESCRIPTION
```hx
class Main {
    static function main() {
        trace((new hxbit.Serializer()).serialize(new Hoge([1,2,3])).toHex());
    }
}

class Hoge implements hxbit.Serializable {
    public function new(fuga: Array<Int>) {
        this.fuga = fuga;
    }

    @:s public var fuga: Array<Int>;
}
```

```
-main Main
-lib hxbit
--interp
--macro nullSafety("Main", Strict)
```

```
> haxe build.hxml
Main.hx:12: characters 6-34 : Null safety: Cannot assign nullable value here.
```

I want to use nullSafety in my project.
`-D hxbit_nullsafety` flag, Initialize with the default value, not null.