### PR TITLE
replaced deprecated Std.is with Std.isOfTypes

### DIFF
--- a/hxbit/NetworkHost.hx
+++ b/hxbit/NetworkHost.hx
@@ -518,7 +518,7 @@ class NetworkHost {
 		flush();
 		var prev = targetClient;
 		targetClient = to;
-		if( Std.is(msg, haxe.io.Bytes) ) {
+		if( Std.isOfType(msg, haxe.io.Bytes) ) {
 			ctx.addByte(BMSG);
 			ctx.addBytes(msg);
 		} else {

--- a/hxbit/NetworkStats.hx
+++ b/hxbit/NetworkStats.hx
@@ -77,7 +77,7 @@ class NetworkStats {
 				size++;
 			else {
 
-				if( Std.is(v, hxbit.NetworkSerializable.BaseProxy) ) v = v.map;
+				if( Std.isOfType(v, hxbit.NetworkSerializable.BaseProxy) ) v = v.map;
 
 				switch( kt ) {
 				case PInt:
@@ -102,7 +102,7 @@ class NetworkStats {
 			}
 		case PArray(at):
 
-			if( Std.is(v, hxbit.NetworkSerializable.BaseProxy) ) v = v.array;
+			if( Std.isOfType(v, hxbit.NetworkSerializable.BaseProxy) ) v = v.array;
 
 			var a : Array<Dynamic> = v;
 			if( a == null )
@@ -152,7 +152,7 @@ class NetworkStats {
 		case PInt64:
 			size += 8;
 		case PFlags(_):
-			if( Std.is(v, hxbit.NetworkSerializable.BaseProxy) ) v = v.value;
+			if( Std.isOfType(v, hxbit.NetworkSerializable.BaseProxy) ) v = v.value;
 			size += intSize(v);
 		case PStruct:
 			// TODO

--- a/hxbit/Serializer.hx
+++ b/hxbit/Serializer.hx
@@ -431,7 +431,7 @@ class Serializer {
 				addByte(8);
 				addBytes(v);
 			default:
-				if( Std.is(v,Serializable) ) {
+				if( Std.isOfType(v,Serializable) ) {
 					addByte(9);
 					addAnyRef(v);
 				} else
@@ -456,7 +456,7 @@ class Serializer {
 			addByte(0);
 			return;
 		}
-		var c : Serializable = Std.is(s, Serializable) ? cast s : null;
+		var c : Serializable = Std.isOfType(s, Serializable) ? cast s : null;
 		if( c != null ) {
 			addByte(1);
 			addAnyRef(c);
@@ -975,7 +975,7 @@ class Serializer {
 			case PString:
 				var v : Map<String,Dynamic> = v;
 				addMap(v, function(v) writeValue(v, k), function(v) writeValue(v, t));
-			case PEnum(_) if( Std.is(v,haxe.ds.EnumValueMap) ):
+			case PEnum(_) if( Std.isOfType(v,haxe.ds.EnumValueMap) ):
 				var v : haxe.ds.EnumValueMap<Dynamic,Dynamic> = v;
 				if( v == null ) {
 					addByte(0);


### PR DESCRIPTION
I replaced all occurrences of `Std.is` in favour of `Std.isOfType` as the former one has been deprecated since Haxe version 4.1.0.


```
C:\HaxeToolkit\haxe\lib\hxbit/git/hxbit/Serializer.hx:434: characters 9-31 : Warning : Std.is is deprecated. Use Std.isOfType instead.
C:\HaxeToolkit\haxe\lib\hxbit/git/hxbit/Serializer.hx:459: characters 26-49 : Warning : Std.is is deprecated. Use Std.isOfType instead. 
C:\HaxeToolkit\haxe\lib\hxbit/git/hxbit/Serializer.hx:978: characters 22-52 : Warning : Std.is is deprecated. Use Std.isOfType instead. 
C:\HaxeToolkit\haxe\lib\hxbit/git/hxbit/NetworkHost.hx:521: characters 7-33 : Warning : Std.is is deprecated. Use Std.isOfType instead. 
C:\HaxeToolkit\haxe\lib\hxbit/git/hxbit/NetworkStats.hx:80: characters 9-55 : Warning : Std.is is deprecated. Use Std.isOfType instead. 
C:\HaxeToolkit\haxe\lib\hxbit/git/hxbit/NetworkStats.hx:105: characters 8-54 : Warning : Std.is is deprecated. Use Std.isOfType instead.
C:\HaxeToolkit\haxe\lib\hxbit/git/hxbit/NetworkStats.hx:155: characters 8-54 : Warning : Std.is is deprecated. Use Std.isOfType instead.
```