### PR TITLE
allow manual call of buildNetworkSerializable + fixes

### DIFF
--- a/hxbit/Macros.hx
+++ b/hxbit/Macros.hx
@@ -1045,11 +1045,12 @@ class Macros {
 		}
 	}
 
-	public static function buildNetworkSerializable() {
+	public static function buildNetworkSerializable(?fields: Array<Field>) {
 		var cl = Context.getLocalClass().get();
 		if( cl.isInterface || Context.defined("display") )
 			return null;
-		var fields = Context.getBuildFields();
+		if(fields == null)
+			fields = Context.getBuildFields();
 		var toSerialize = [];
 		var rpc = [];
 		var superRPC = new Map();
@@ -1321,17 +1322,20 @@ class Macros {
 				var resultCall = macro null;
 
 				if( hasReturnVal ) {
-					doCall = macro onResult($fcall);
+					doCall = macro {
+						var _v = $fcall;
+						if( onResult != null ) onResult(_v);
+					}
 					resultCall = withPos(macro function(__ctx:hxbit.NetworkSerializable.NetworkSerializer) {
-						var v = cast null;
-						if( false ) v = $fcall;
-						hxbit.Macros.unserializeValue(__ctx, v);
+						var _v = cast null;
+						if( false ) _v = $fcall;
+						hxbit.Macros.unserializeValue(__ctx, _v);
 						if( __ctx.error ) return false;
-						onResult(v);
+						if( onResult != null ) onResult(_v);
 						return true;
 					},f.expr.pos);
 					rpcArgs = rpcArgs.copy();
-					rpcArgs.push( { name : "onResult", type: f.ret == null ? null : TFunction([f.ret], macro:Void) } );
+					rpcArgs.push( { name : "onResult", opt: true, type: f.ret == null ? null : TFunction([f.ret], macro:Void) } );
 				}
 
 				var forwardRPC = macro {

--- a/hxbit/NetworkSerializable.hx
+++ b/hxbit/NetworkSerializable.hx
@@ -58,7 +58,9 @@ abstract Operation(Int) {
 	public var Unregister = 5;
 }
 
+#if !hxbit_manual_build
 @:autoBuild(hxbit.Macros.buildNetworkSerializable())
+#end
 interface NetworkSerializable extends Serializable extends ProxyHost {
 	public var __host : NetworkHost;
 	public var __bits1 : Int;


### PR DESCRIPTION
This PR includes:
- ability to manually call `buildNetworkSerializable`, passing list of fields, useful to chain hxbit macros on top of macro-generated functions (hence added arg to `buildNetworkSerializable`)
- fix for naming clash when passing a `v` arg to a @:rpc function
- optionnal `onResult` rpc callback