### PR TITLE
hxbit triggers an error when unserializing a struct client-side

### DIFF
--- a/hxbit/Macros.hx
+++ b/hxbit/Macros.hx
@@ -776,8 +776,9 @@ class Macros {
 					$v = null;
 				else {
 					@:privateAccess $ctx.inPos--;
-					$v = Type.createEmptyInstance($cexpr);
-					$v.unserialize($ctx);
+					var tmp = Type.createEmptyInstance($cexpr);
+					tmp.unserialize($ctx);
+					$v = tmp;
 				}
 			}
 		case PUnknown:


### PR DESCRIPTION
Issue: hxbit triggers an error when unserializing a struct client-side if the struct has more than one property

Fix:
Unserializing struct on temporary variable before affecting it to the object's field.