### PR TITLE
Ignore @:isVar on serializable fields

### DIFF
--- a/hxbit/Macros.hx
+++ b/hxbit/Macros.hx
@@ -298,7 +298,7 @@ class Macros {
 			return null;
 		for( m in meta) {
 			switch( m.name ) {
-			case ":s", ":optional", ":serializePriority",":allowCDB":
+			case ":s", ":optional", ":serializePriority", ":allowCDB", ":isVar":
 				//
 			case ":increment":
 				var inc : Null<Float> = null;


### PR DESCRIPTION
Before, this would throw `Unsupported network metadata`
```
@:isVar @:s var mySerialized;
```