### PR TITLE
Add __net_bit_fieldName to NetworkSerializables

### DIFF
--- a/hxbit/Macros.hx
+++ b/hxbit/Macros.hx
@@ -1917,6 +1917,13 @@ class Macros {
 					}
 				}),
 			});
+			fields.push({
+				name : "__net_bit_" + f.f.name,
+				access : [AStatic, AInline],
+				meta : noComplete,
+				pos : pos,
+				kind : FVar(macro: Int, macro $v{ bitID }),
+			});
 
 			var found = false;
 			for( set in fields )


### PR DESCRIPTION
Sometimes you need to do something like

```haxe
@:s @:condSend(specialCondition()) var fieldName;

override function networkAllow(mode, prop, client) {
	if (!specialCondition()) {
		if (mode == SetField && propIsFieldName(prop))
			return true;
	}
	return super.networkAllow(mode, prop, client);
}
```

Where the condition is specific enough that you wouldn't want to add a meta and a custom getter just for that one field.

This PR allows doing `prop == __net_bit_fieldName` instead of `networkGetName` and a String comparison every time
