### PR TITLE
Fix @:condSend() when used with Proxy types

### DIFF
--- a/hxbit/Macros.hx
+++ b/hxbit/Macros.hx
@@ -2664,9 +2664,8 @@ class Macros {
 					var bit : Int;
 					@:noCompletion public var __value(get, never) : $pt;
 					inline function get___value() : $pt return cast this;
-					inline function mark() if( obj != null ) obj.networkSetBit(bit);
-					@:noCompletion public function networkSetBit(_) mark();
-					@:noCompletion public function networkSetBitCond(b) networkSetBit(b);
+					public inline function mark() if( obj != null ) obj.networkSetBitCond(bit);
+					@:noCompletion public inline function networkSetBitCond(_) mark();
 					@:noCompletion public function bindHost(obj, bit) { this.obj = obj; this.bit = bit; }
 					@:noCompletion public function unbindHost() this.obj = null;
 					@:noCompletion public function toString() return hxbit.NetworkSerializable.BaseProxy.objToString(this);

--- a/hxbit/Macros.hx
+++ b/hxbit/Macros.hx
@@ -1825,6 +1825,7 @@ class Macros {
 		var flushExpr = [];
 		var syncExpr = [];
 		var initExpr = [];
+		var condMarkCases: Array<Case> = [];
 		var noComplete : Metadata = [ { name : ":noCompletion", pos : pos } ];
 		var saveMask : haxe.Int64 = 0;
 		for( f in toSerialize ) {
@@ -1964,6 +1965,31 @@ class Macros {
 					ret : null,
 				}),
 				access : [AInline],
+			});
+			condMarkCases.push({
+				values : [macro $v{bitID}],
+				expr : markExpr,
+			});
+		}
+
+		if( toSerialize.length != 0 || !isSubSer ) {
+			var access = [APublic];
+			if( isSubSer )
+				access.push(AOverride);
+			var defaultCase = macro networkSetBit(b);
+			if( isSubSer )
+				defaultCase = macro super.networkSetBitCond(b);
+			var swExpr = { expr : ESwitch( { expr : EConst(CIdent("b")), pos : pos }, condMarkCases, defaultCase), pos : pos };
+			fields.push({
+				name : "networkSetBitCond",
+				pos : pos,
+				access : access,
+				meta : noComplete,
+				kind : FFun({
+					args : [ { name : "b", type : macro : Int } ],
+					ret : macro : Void,
+					expr : swExpr,
+				}),
 			});
 		}
 
@@ -2640,6 +2666,7 @@ class Macros {
 					inline function get___value() : $pt return cast this;
 					inline function mark() if( obj != null ) obj.networkSetBit(bit);
 					@:noCompletion public function networkSetBit(_) mark();
+					@:noCompletion public function networkSetBitCond(b) networkSetBit(b);
 					@:noCompletion public function bindHost(obj, bit) { this.obj = obj; this.bit = bit; }
 					@:noCompletion public function unbindHost() this.obj = null;
 					@:noCompletion public function toString() return hxbit.NetworkSerializable.BaseProxy.objToString(this);

--- a/hxbit/NetworkSerializable.hx
+++ b/hxbit/NetworkSerializable.hx
@@ -23,6 +23,7 @@ package hxbit;
 
 interface ProxyHost {
 	public function networkSetBit( bit : Int ) : Void;
+	public function networkSetBitCond( bit : Int ) : Void;
 }
 
 interface ProxyChild {
@@ -98,8 +99,11 @@ class BaseProxy implements ProxyHost implements ProxyChild {
 	public inline function networkSetBit(_) {
 		mark();
 	}
+	public inline function networkSetBitCond(b) {
+		networkSetBit(b);
+	}
 	public inline function mark() {
-		if( obj != null ) obj.networkSetBit(bit);
+		if( obj != null ) obj.networkSetBitCond(bit);
 	}
 	public inline function bindHost(o, bit) {
 		if( obj != null && (o != this.obj || bit != this.bit) )

--- a/hxbit/NetworkSerializable.hx
+++ b/hxbit/NetworkSerializable.hx
@@ -22,7 +22,6 @@
 package hxbit;
 
 interface ProxyHost {
-	public function networkSetBit( bit : Int ) : Void;
 	public function networkSetBitCond( bit : Int ) : Void;
 }
 
@@ -82,6 +81,7 @@ interface NetworkSerializable extends Serializable extends ProxyHost {
 	public function networkRPC( ctx : NetworkSerializer, rpcID : Int, clientResult : NetworkHost.NetworkClient ) : Bool;
 	public function networkAllow( op : Operation, propId : Int, client : NetworkSerializable ) : Bool;
 	public function networkGetName( propId : Int, isRPC : Bool = false ) : String;
+	public function networkSetBit( bit : Int ) : Void;
 
 	#if hxbit_visibility
 	public var __cachedVisibility : Map<hxbit.NetworkSerializable,Int>;
@@ -96,11 +96,8 @@ interface NetworkSerializable extends Serializable extends ProxyHost {
 class BaseProxy implements ProxyHost implements ProxyChild {
 	public var obj : ProxyHost;
 	public var bit : Int;
-	public inline function networkSetBit(_) {
+	@:noCompletion public inline function networkSetBitCond(_) {
 		mark();
-	}
-	public inline function networkSetBitCond(b) {
-		networkSetBit(b);
 	}
 	public inline function mark() {
 		if( obj != null ) obj.networkSetBitCond(bit);


### PR DESCRIPTION
Note that this was rarely an issue since `condSend` is usually used with just `false`, and that doesn't create a proxy field