### PR TITLE
Fix incorrect 'has no field' error on completion

### DIFF
--- a/hxbit/Macros.hx
+++ b/hxbit/Macros.hx
@@ -552,7 +552,7 @@ class Macros {
 	}
 
 	static function toType( t : ComplexType ) : Type {
-		return Context.typeof(macro (null:$t));
+		return ComplexTypeTools.toType(t);
 	}
 
 


### PR DESCRIPTION
This error happened on our project whenever opening Skill.hx in vscode (but still compiled properly)

Thanks to @kLabz for the fix